### PR TITLE
Straight/biteasy adapter

### DIFF
--- a/lib/straight.rb
+++ b/lib/straight.rb
@@ -8,6 +8,7 @@ require 'yaml'
 require_relative 'straight/blockchain_adapter'
 require_relative 'straight/blockchain_adapters/blockchain_info_adapter'
 require_relative 'straight/blockchain_adapters/helloblock_io_adapter'
+require_relative 'straight/blockchain_adapters/biteasy_adapter'
 
 require_relative 'straight/exchange_rate_adapter'
 require_relative 'straight/exchange_rate_adapters/bitpay_adapter'

--- a/lib/straight/blockchain_adapters/biteasy_adapter.rb
+++ b/lib/straight/blockchain_adapters/biteasy_adapter.rb
@@ -27,6 +27,12 @@ module Straight
         straighten_transaction JSON.parse(http_request("#{@base_url}/transactions/#{tid}"), address: address)
       end
 
+      # Returns all transactions for the address
+      def fetch_transactions_for(address)
+        transactions = JSON.parse(http_request("#{@base_url}/transactions?address=#{address}"))['data']['transactions']
+        transactions.map { |t| straighten_transaction(t, address: address) }
+      end
+
       private
 
         # Converts transaction info received from the source into the

--- a/lib/straight/blockchain_adapters/biteasy_adapter.rb
+++ b/lib/straight/blockchain_adapters/biteasy_adapter.rb
@@ -22,6 +22,31 @@ module Straight
         JSON.parse(http_request("#{@base_url}/addresses/#{address}"))['data']['balance']
       end
 
+      # Returns transaction info for the tid
+      def fetch_transaction(tid, address: nil)
+        straighten_transaction JSON.parse(http_request("#{@base_url}/transactions/#{tid}"), address: address)
+      end
+
+      private
+
+        # Converts transaction info received from the source into the
+        # unified format expected by users of BlockchainAdapter instances.
+        def straighten_transaction(transaction, address: nil)
+          outs         = []
+          total_amount = 0
+          transaction['data']['outputs'].each do |out|
+            total_amount += out['value'] if address.nil? || address == out['to_address']
+            outs << { amount: out['value'], receiving_address: out['to_address'] } 
+          end
+
+          {
+            tid:           transaction['data']['hash'],
+            total_amount:  total_amount,
+            confirmations: transaction['data']['confirmations'],
+            outs:          outs
+          }
+        end
+
     end
 
   end

--- a/lib/straight/blockchain_adapters/biteasy_adapter.rb
+++ b/lib/straight/blockchain_adapters/biteasy_adapter.rb
@@ -1,0 +1,10 @@
+module Straight
+  module Blockchain
+
+    class BiteasyAdapter < Adapter
+
+    end
+
+  end
+
+end

--- a/lib/straight/blockchain_adapters/biteasy_adapter.rb
+++ b/lib/straight/blockchain_adapters/biteasy_adapter.rb
@@ -17,8 +17,6 @@ module Straight
 
       # Returns the current balance of the address
       def fetch_balance_for(address)
-        # I would like to check if address in returning hash matches our address in passed params
-        # seems like it will be safer
         JSON.parse(http_request("#{@base_url}/addresses/#{address}"))['data']['balance']
       end
 

--- a/lib/straight/blockchain_adapters/biteasy_adapter.rb
+++ b/lib/straight/blockchain_adapters/biteasy_adapter.rb
@@ -3,6 +3,25 @@ module Straight
 
     class BiteasyAdapter < Adapter
 
+      def self.mainnet_adapter
+        self.new("https://api.biteasy.com/blockchain/v1")
+      end
+      
+      def self.testnet_adapter
+        raise "Not Supported Yet"
+      end
+      
+      def initialize(base_url)
+        @base_url = base_url
+      end
+
+      # Returns the current balance of the address
+      def fetch_balance_for(address)
+        # I would like to check if address in returning hash matches our address in passed params
+        # seems like it will be safer
+        JSON.parse(http_request("#{@base_url}/addresses/#{address}"))['data']['balance']
+      end
+
     end
 
   end

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-# require 'byebug'; debugger
 
 RSpec.describe Straight::Blockchain::BiteasyAdapter do
 

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -26,4 +26,19 @@ RSpec.describe Straight::Blockchain::BiteasyAdapter do
     expect(adapter.fetch_transactions_for(address)).not_to be_empty
   end
 
+  it "calculates the number of confirmations for each transaction" do
+    tid = 'ae0d040f48d75fdc46d9035236a1782164857d6f0cca1f864640281115898560'
+    expect(adapter.fetch_transaction(tid)[:confirmations]).to be > 0
+  end
+
+  it "gets a transaction id among other data" do
+    tid = 'ae0d040f48d75fdc46d9035236a1782164857d6f0cca1f864640281115898560'
+    expect(adapter.fetch_transaction(tid)[:tid]).to eq(tid)
+  end
+
+  it "raises an exception when something goes wrong with fetching datd" do
+    allow_any_instance_of(URI::HTTPS).to receive(:read).and_raise(OpenURI::HTTPError.new('https connection error', nil))
+    expect( -> { adapter.http_request("https://blockchain.info/a-timed-out-request") }).to raise_error(Straight::Blockchain::Adapter::RequestError)
+  end
+
 end

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Straight::Blockchain::BiteasyAdapter do
 
   it "raises an exception when something goes wrong with fetching datd" do
     allow_any_instance_of(URI::HTTPS).to receive(:read).and_raise(OpenURI::HTTPError.new('https connection error', nil))
-    expect( -> { adapter.http_request("https://blockchain.info/a-timed-out-request") }).to raise_error(Straight::Blockchain::Adapter::RequestError)
+    expect( -> { adapter.http_request("https://api.biteasy.com/a-timed-out-request") }).to raise_error(Straight::Blockchain::Adapter::RequestError)
   end
 
 end

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+RSpec.describe Straight::Blockchain::BiteasyAdapter do
+  
+end

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -20,4 +20,10 @@ RSpec.describe Straight::Blockchain::BiteasyAdapter do
     expect(adapter.send(:straighten_transaction, t, address: 'address1')[:total_amount]).to eq(1)
   end
 
+  it "fetches all transactions for the current address" do
+    address = "3B1QZ8FpAaHBgkSB5gFt76ag5AW9VeP8xp"
+    expect(adapter).to receive(:straighten_transaction).with(anything, address: address).at_least(:once)
+    expect(adapter.fetch_transactions_for(address)).not_to be_empty
+  end
+
 end

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -1,5 +1,12 @@
 require 'spec_helper'
 
 RSpec.describe Straight::Blockchain::BiteasyAdapter do
-  
+
+  subject(:adapter) { Straight::Blockchain::BiteasyAdapter.mainnet_adapter }
+
+  it "fetches the balance for a given address" do
+    address = "3B1QZ8FpAaHBgkSB5gFt76ag5AW9VeP8xp"
+    expect(adapter.fetch_balance_for(address)).to be_kind_of(Integer)
+  end
+
 end

--- a/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
+++ b/spec/lib/blockchain_adapters/biteasy_adapter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+# require 'byebug'; debugger
 
 RSpec.describe Straight::Blockchain::BiteasyAdapter do
 
@@ -7,6 +8,16 @@ RSpec.describe Straight::Blockchain::BiteasyAdapter do
   it "fetches the balance for a given address" do
     address = "3B1QZ8FpAaHBgkSB5gFt76ag5AW9VeP8xp"
     expect(adapter.fetch_balance_for(address)).to be_kind_of(Integer)
+  end
+
+  it "fetches a single transaction" do
+    tid = 'ae0d040f48d75fdc46d9035236a1782164857d6f0cca1f864640281115898560'
+    expect(adapter.fetch_transaction(tid)[:total_amount]).to eq(832947)
+  end
+
+  it "calculates total_amount of a transaction for the given address only" do
+    t = { 'data' => {'outputs' => [{ 'value' => 1, 'to_address' => 'address1'}, { 'value' => 2, 'to_address' => 'address2'}] } }
+    expect(adapter.send(:straighten_transaction, t, address: 'address1')[:total_amount]).to eq(1)
   end
 
 end

--- a/spec/lib/blockchain_adapters/blockchain_info_spec.rb
+++ b/spec/lib/blockchain_adapters/blockchain_info_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Straight::Blockchain::BlockchainInfoAdapter do
 
   it "fetches all transactions for the current address" do
     address = "3B1QZ8FpAaHBgkSB5gFt76ag5AW9VeP8xp"
+    require 'byebug'; debugger;
     expect(adapter).to receive(:straighten_transaction).with(anything, address: address).at_least(:once)
     expect(adapter.fetch_transactions_for(address)).not_to be_empty
   end

--- a/spec/lib/blockchain_adapters/blockchain_info_spec.rb
+++ b/spec/lib/blockchain_adapters/blockchain_info_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Straight::Blockchain::BlockchainInfoAdapter do
 
   it "fetches all transactions for the current address" do
     address = "3B1QZ8FpAaHBgkSB5gFt76ag5AW9VeP8xp"
-    require 'byebug'; debugger;
     expect(adapter).to receive(:straighten_transaction).with(anything, address: address).at_least(:once)
     expect(adapter.fetch_transactions_for(address)).not_to be_empty
   end


### PR DESCRIPTION
Sometimes specs fails due to Net::ReadTimeout, in Blockchain::Adapter in #http_request you have read_timeout: 4, I dint touch it. But I tested manually and it was giving responds slow. like 5ish seconds.
Maybe is my network, which I doubt in, or maybe increasing read_timeout would work ok.

left comment in #fetch_balance_for in BiteasyAdapter regarding extra caution, maybe we dont need that, but if you say yes I will add that address verification.
