### PR TITLE
Straight/okcoin exchange rate adapter

### DIFF
--- a/lib/straight.rb
+++ b/lib/straight.rb
@@ -13,6 +13,7 @@ require_relative 'straight/exchange_rate_adapter'
 require_relative 'straight/exchange_rate_adapters/bitpay_adapter'
 require_relative 'straight/exchange_rate_adapters/coinbase_adapter'
 require_relative 'straight/exchange_rate_adapters/bitstamp_adapter'
+require_relative 'straight/exchange_rate_adapters/okcoin_adapter'
 
 require_relative 'straight/order'
 require_relative 'straight/gateway'

--- a/lib/straight/exchange_rate_adapter.rb
+++ b/lib/straight/exchange_rate_adapter.rb
@@ -40,6 +40,19 @@ module Straight
         nil # this should be changed in descendant classes
       end
 
+      # If response returnes hash, this method will get value we are interested in according to
+      # *keys we pass or return nil if it cant get that value, its used in child adapters and 
+      # prevent failing with 'undefined method [] for Nil' if at some point hash doesnt have such key value pair
+      def get_rate_value_from_hash(rates_hash, *keys)
+        keys.inject(rates_hash) do |intermediate, key|
+          if intermediate.respond_to?(:[])
+            intermediate[key]
+          else
+            raise CurrencyNotSupported 
+          end
+        end
+      end
+
       # this method will be used in #rate_for method in child classes, and will be checking that 
       # rate value != nil
       def rate_to_f(rate)

--- a/lib/straight/exchange_rate_adapter.rb
+++ b/lib/straight/exchange_rate_adapter.rb
@@ -6,6 +6,7 @@ module Straight
       class CurrencyNotFound     < Exception; end
       class FetchingFailed       < Exception; end
       class CurrencyNotSupported < Exception; end
+      class NilValueNotAllowed   < Exception; end
 
       def initialize(rates_expire_in: 1800)
         @rates_expire_in = rates_expire_in # in seconds
@@ -37,6 +38,12 @@ module Straight
           fetch_rates!
         end
         nil # this should be changed in descendant classes
+      end
+
+      # this method will be used in #rate_for method in child classes, and will be checking that 
+      # rate value != nil
+      def rate_to_f(rate)
+        rate ? rate.to_f : raise(NilValueNotAllowed)
       end
 
     end

--- a/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
+++ b/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
@@ -8,7 +8,8 @@ module Straight
       def rate_for(currency_code)
         super
         raise CurrencyNotSupported if currency_code != 'USD'
-        rate_to_f(@rates['ticker']['last'])
+        rate = get_rate_value_from_hash(@rates, 'ticker', 'last')
+        rate_to_f(rate)
       end
 
     end

--- a/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
+++ b/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
@@ -8,7 +8,7 @@ module Straight
       def rate_for(currency_code)
         super
         raise CurrencyNotSupported if currency_code != 'USD'
-        @rates['ticker']['last'].to_f
+        rate_to_f(@rates['ticker']['last'])
       end
 
     end

--- a/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
+++ b/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
@@ -8,7 +8,7 @@ module Straight
       def rate_for(currency_code)
         super
         raise CurrencyNotSupported if currency_code != 'USD'
-        @rates['last'].to_f
+        @rates['ticker']['last'].to_f
       end
 
     end

--- a/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
+++ b/lib/straight/exchange_rate_adapters/okcoin_adapter.rb
@@ -1,0 +1,17 @@
+module Straight
+  module ExchangeRate
+
+    class OkcoinAdapter < Adapter
+      
+      FETCH_URL = 'https://www.okcoin.com/api/ticker.do?ok=1'
+
+      def rate_for(currency_code)
+        super
+        raise CurrencyNotSupported if currency_code != 'USD'
+        @rates['last'].to_f
+      end
+
+    end
+
+  end
+end

--- a/spec/lib/exchange_rate_adapters/okcoin_adapter_spec.rb
+++ b/spec/lib/exchange_rate_adapters/okcoin_adapter_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe Straight::ExchangeRate::OkcoinAdapter do
   end
 
   it "rases exception if rate is nil" do
-    expect( -> { @exchange_adapter.rate_to_f(nil) }).to raise_error(Straight::ExchangeRate::Adapter::NilValueNotAllowed)
+    uri_mock = double('uri mock')
+    allow(uri_mock).to receive(:read).with(read_timeout: 4).and_return(nil)
+    allow(URI).to       receive(:parse).and_return(uri_mock)
+    allow(@exchange_adapter).to receive(:fetch_rates!)
+    expect( -> { @exchange_adapter.rate_for('USD') }).to raise_error(Straight::ExchangeRate::Adapter::CurrencyNotSupported)
   end
 
 end

--- a/spec/lib/exchange_rate_adapters/okcoin_adapter_spec.rb
+++ b/spec/lib/exchange_rate_adapters/okcoin_adapter_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe Straight::ExchangeRate::OkcoinAdapter do
+
+  before(:each) do
+    @exchange_adapter = Straight::ExchangeRate::OkcoinAdapter.new
+  end
+
+  it "finds the rate for currency code" do
+    expect(@exchange_adapter.rate_for('USD')).to be_kind_of(Float)
+    expect( -> { @exchange_adapter.rate_for('FEDcoin') }).to raise_error(Straight::ExchangeRate::Adapter::CurrencyNotSupported)
+  end
+
+end

--- a/spec/lib/exchange_rate_adapters/okcoin_adapter_spec.rb
+++ b/spec/lib/exchange_rate_adapters/okcoin_adapter_spec.rb
@@ -11,4 +11,8 @@ RSpec.describe Straight::ExchangeRate::OkcoinAdapter do
     expect( -> { @exchange_adapter.rate_for('FEDcoin') }).to raise_error(Straight::ExchangeRate::Adapter::CurrencyNotSupported)
   end
 
+  it "rases exception if rate is nil" do
+    expect( -> { @exchange_adapter.rate_to_f(nil) }).to raise_error(Straight::ExchangeRate::Adapter::NilValueNotAllowed)
+  end
+
 end


### PR DESCRIPTION
If you agree with #rate_to_f implementation I will add that to all other adapters in separate branch created just for this purpose. I am also confused with raise CurrencyNotSupported if currency_code != 'USD' in OkcoinAdapter#rate_for. It doesnt make any weather but we can leave it for now maybe they will support other currencies in a future. 
